### PR TITLE
CFG Graph Visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .zig-cache/
-zig-out/
-temp/
 .vscode/
-traces/
+zig-out/
 
-# Don't want any artifacts
+graph/*
+!graph/plot.py
+
+traces/
 **/__pycache__
 demo/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ zig-out/
 
 graph/*
 !graph/plot.py
+!graph/requirements.txt
 
 traces/
 **/__pycache__

--- a/graph/plot.py
+++ b/graph/plot.py
@@ -1,0 +1,107 @@
+import struct
+import matplotlib.pyplot as plt
+import networkx as nx
+import math
+
+def get_offset_pos(pos, edges, offset_scale=0.03):
+    offset_pos = {node: pos[node] for node in pos}
+    for edge in edges:
+        x1, y1 = pos[edge[0]]
+        x2, y2 = pos[edge[1]]
+        dx = x2 - x1
+        dy = y2 - y1
+        length = math.sqrt(dx*dx + dy*dy)
+        if length == 0:
+            continue
+        offset_x = offset_scale * dy / length
+        offset_y = -offset_scale * dx / length
+        offset_pos[edge[0]] = (offset_pos[edge[0]][0] + offset_x, offset_pos[edge[0]][1] + offset_y)
+        offset_pos[edge[1]] = (offset_pos[edge[1]][0] + offset_x, offset_pos[edge[1]][1] + offset_y)
+    return offset_pos
+
+def read_graph_binary(filename):
+    nodes = []
+    edges = []
+    cfg_edges = []
+
+    with open(filename, "rb") as file:
+        while True:
+            node_id_bytes = file.read(4)
+            if not node_id_bytes:
+                break
+            node_id = struct.unpack("i", node_id_bytes)[0]
+            if node_id == -1:
+                break
+            data_len = struct.unpack("Q", file.read(8))[0]
+            data = file.read(data_len).decode("utf-8")
+            nodes.append((node_id, data))
+
+        while True:
+            edge_from_bytes = file.read(4)
+            if not edge_from_bytes:
+                break
+            edge_from = struct.unpack("i", edge_from_bytes)[0]
+            if edge_from == -1:
+                break
+            edge_to = struct.unpack("i", file.read(4))[0]
+            edges.append((edge_from, edge_to))
+
+        while True:
+            cfg_from_bytes = file.read(4)
+            if not cfg_from_bytes:
+                break
+            cfg_from = struct.unpack("i", cfg_from_bytes)[0]
+            cfg_to = struct.unpack("i", file.read(4))[0]
+            cfg_edges.append((cfg_from, cfg_to))
+
+    return nodes, edges, cfg_edges
+
+nodes, edges, cfg_edges = read_graph_binary("graph.bin")
+
+G = nx.DiGraph()
+
+for node in nodes:
+    G.add_node(node[0], label=node[1])
+
+for edge in edges:
+    G.add_edge(edge[0], edge[1])
+
+predecessors = {cfg_edge[1] for cfg_edge in cfg_edges}
+nodes_with_edges = [node for node in G.nodes if G.out_degree(node) > 0 or G.in_degree(node) > 0 and node in predecessors]
+
+G_filtered = G.subgraph(nodes_with_edges).copy()
+
+# Coloring the first and last nodes in the CFG
+first_node = cfg_edges[0][0]
+predecessors = {cfg_edge[1] for cfg_edge in cfg_edges}
+nodes_with_no_successors = {node for node in G_filtered.nodes if all(cfg_edge[0] != node for cfg_edge in cfg_edges) and node in predecessors}
+
+node_colors = ['green' if node == first_node else 'red' if node in nodes_with_no_successors else 'skyblue' for node in G_filtered.nodes]
+
+pos = nx.nx_agraph.graphviz_layout(G_filtered, prog='dot')
+plt.figure(figsize=(15, 10))
+nx.draw(G_filtered, pos, with_labels=True, labels=nx.get_node_attributes(G_filtered, 'label'), node_color=node_colors, node_size=3000, font_size=10, font_color='black', font_weight='bold', edge_color='gray')
+
+data_edges_pos = pos
+cfg_edges_pos = get_offset_pos(pos, cfg_edges)
+
+for edge in edges:
+    if edge[0] in G_filtered and edge[1] in G_filtered:
+        nx.draw_networkx_edges(G_filtered, data_edges_pos, edgelist=[edge], edge_color='gray', arrows=True)
+
+scale = 4
+
+for cfg_edge in cfg_edges:
+    if cfg_edge[0] in G_filtered and cfg_edge[1] in G_filtered:
+        x1, y1 = pos[cfg_edge[0]]
+        x2, y2 = cfg_edges_pos[cfg_edge[1]]
+        dx = x2 - x1
+        dy = y2 - y1
+        length = math.sqrt(dx*dx + dy*dy)
+        if length == 0:
+            continue
+        offset_x = scale * dy / length
+        offset_y = -scale * dx / length
+        plt.arrow(x1 + offset_x, y1 + offset_y, dx, dy, color='red', linewidth=1, head_width=0.1, head_length=0.2)
+
+plt.savefig("out.png")

--- a/graph/requirements.txt
+++ b/graph/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib >= 3.8.4
+networkx >= 2.8.8

--- a/src/compiler/Instruction.zig
+++ b/src/compiler/Instruction.zig
@@ -71,6 +71,15 @@ fn format2(
     }
 }
 
+pub fn returns(
+    inst: Instruction,
+) bool {
+    return switch (inst.op) {
+        .RETURN_VALUE => true,
+        else => false,
+    };
+}
+
 pub fn fmt(inst: Instruction, co: CodeObject) std.fmt.Formatter(format2) {
     return .{ .data = .{
         .co = co,

--- a/src/graph/Graph.zig
+++ b/src/graph/Graph.zig
@@ -1,0 +1,274 @@
+//! Creates a temporal graph of a CodeObject
+
+const std = @import("std");
+const CodeObject = @import("../compiler/CodeObject.zig");
+const Instruction = @import("../compiler/Instruction.zig");
+const builtins = @import("../modules/builtins.zig");
+const log = std.log.scoped(.graph);
+const Graph = @This();
+
+const assert = std.debug.assert;
+
+allocator: std.mem.Allocator,
+nodes: std.MultiArrayList(Node) = .{},
+edges: std.MultiArrayList(Edge) = .{},
+co: CodeObject,
+
+/// shows the control flow of nodes
+cfg: std.MultiArrayList(Edge) = .{},
+
+scope: std.StringHashMapUnmanaged(u32) = .{},
+
+pub fn evaluate(
+    allocator: std.mem.Allocator,
+    input_co: CodeObject,
+) !Graph {
+    var co = try input_co.clone(allocator);
+    try co.process(allocator);
+    const instructions = co.instructions.?;
+
+    var graph: Graph = .{
+        .allocator = allocator,
+        .co = co,
+    };
+
+    // insert some names that will always exist into the graph to depend on
+    inline for (builtins.builtin_fns) |entry| {
+        const name = entry[0];
+        try graph.nodes.append(allocator, .{
+            .data = .none,
+            .name = name,
+        });
+        try graph.scope.put(
+            allocator,
+            name,
+            @intCast(graph.nodes.len - 1),
+        );
+    }
+
+    for (instructions, 0..) |inst, i| {
+        try graph.walkInst(inst);
+        const new_index: u32 = @intCast(graph.nodes.len - 1);
+        if (i != 0 and !instructions[i - 1].returns()) {
+            try graph.cfg.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+        }
+    }
+
+    return graph;
+}
+
+pub fn walkInst(graph: *Graph, inst: Instruction) !void {
+    log.debug("walkInst: {s}", .{@tagName(inst.op)});
+
+    const allocator = graph.allocator;
+    try graph.nodes.append(allocator, .{
+        .data = .none,
+        .name = @tagName(inst.op),
+    });
+    const new_index: u32 = @intCast(graph.nodes.len - 1);
+
+    switch (inst.op) {
+        // these instructions have a direct edge to the instruction above them.
+        // usually when the instruction pops one off of the stack.
+        .POP_TOP,
+        .RETURN_VALUE,
+        .LOAD_METHOD,
+        => {
+            try graph.edges.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+        },
+
+        // same thing as above, but relies on the two above instructions
+        .CALL_FUNCTION,
+        .MAKE_FUNCTION,
+        .COMPARE_OP,
+        .LIST_EXTEND,
+        .INPLACE_ADD,
+        .BINARY_ADD,
+        .INPLACE_SUBTRACT,
+        .BINARY_SUBTRACT,
+        => {
+            try graph.edges.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+
+            try graph.edges.append(allocator, .{
+                .from = new_index - 2,
+                .to = new_index,
+            });
+        },
+
+        // instructions that only have N arguments
+        .BUILD_LIST,
+        => {
+            for (0..inst.extra) |i| {
+                try graph.edges.append(allocator, .{
+                    .from = new_index - @as(u32, @intCast(i)) - 1,
+                    .to = new_index,
+                });
+            }
+        },
+
+        // function calls have N amount of arguments
+        .CALL_METHOD,
+        => {
+            try graph.edges.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+
+            try graph.edges.append(allocator, .{
+                .from = new_index - 2,
+                .to = new_index,
+            });
+
+            for (0..inst.extra) |i| {
+                try graph.edges.append(allocator, .{
+                    .from = new_index - @as(u32, @intCast(i)) - 3, // 1 for offset, 2 for the above two edges
+                    .to = new_index,
+                });
+            }
+        },
+
+        // we try to create two edges between the node
+        // and both targets it could jump to. in theory,
+        // the number of insts should be the same as the number of nodes,
+        // so we can simply create a forward edge for the node that doens't exist yet
+        .POP_JUMP_IF_FALSE,
+        .POP_JUMP_IF_TRUE,
+        => {
+            // the compare op
+            // fall through
+            try graph.edges.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+
+            // fall through
+            try graph.edges.append(allocator, .{
+                .from = new_index, // ourselves
+                .to = new_index + 1,
+            });
+
+            // target
+            try graph.edges.append(allocator, .{
+                .from = new_index, // ourselves
+                .to = inst.extra + @as(u32, @intCast(builtins.builtin_fns.len)),
+            });
+
+            try graph.cfg.append(allocator, .{
+                .from = new_index,
+                .to = new_index + 1,
+            });
+
+            try graph.cfg.append(allocator, .{
+                .from = new_index,
+                .to = inst.extra + @as(u32, @intCast(builtins.builtin_fns.len)),
+            });
+        },
+
+        .JUMP_FORWARD => {
+            try graph.edges.append(allocator, .{
+                .from = new_index,
+                .to = new_index + inst.extra,
+            });
+
+            try graph.cfg.append(allocator, .{
+                .from = new_index,
+                .to = new_index + inst.extra,
+            });
+        },
+
+        .STORE_NAME => {
+            try graph.edges.append(allocator, .{
+                .from = new_index - 1,
+                .to = new_index,
+            });
+
+            try graph.scope.put(
+                allocator,
+                graph.co.getName(inst.extra),
+                new_index,
+            );
+        },
+
+        .LOAD_NAME => {
+            const dependee = graph.scope.get(graph.co.getName(inst.extra)) orelse {
+                @panic("didn't find dependee");
+            };
+
+            try graph.edges.append(allocator, .{
+                .from = dependee,
+                .to = new_index,
+            });
+        },
+
+        // a dependee, has no dependencies
+        .LOAD_CONST,
+        => {},
+        else => std.debug.panic("TODO: walkInst {s}", .{@tagName(inst.op)}),
+    }
+}
+
+pub fn deinit(graph: *Graph) void {
+    graph.cfg.deinit(graph.allocator);
+    graph.nodes.deinit(graph.allocator);
+    graph.edges.deinit(graph.allocator);
+    graph.co.deinit(graph.allocator);
+    graph.scope.deinit(graph.allocator);
+
+    graph.* = undefined;
+}
+
+pub fn dump(
+    graph: Graph,
+) !void {
+    const outfile = try std.fs.cwd().createFile("graph.bin", .{});
+    defer outfile.close();
+    const writer = outfile.writer();
+
+    const node_names = graph.nodes.items(.name);
+    for (node_names, 0..) |name, id| {
+        try writer.writeInt(u32, @intCast(id), .little);
+        try writer.writeInt(usize, name.len, .little);
+        try writer.writeAll(name);
+    }
+
+    try writer.writeInt(i32, -1, .little);
+
+    const edge_froms = graph.edges.items(.from);
+    const edge_tos = graph.edges.items(.to);
+    for (edge_froms, edge_tos) |from, to| {
+        try writer.writeInt(u32, from, .little);
+        try writer.writeInt(u32, to, .little);
+    }
+
+    try writer.writeInt(i32, -1, .little);
+
+    const cfg_froms = graph.cfg.items(.from);
+    const cfg_tos = graph.cfg.items(.to);
+    for (cfg_froms, cfg_tos) |from, to| {
+        try writer.writeInt(u32, from, .little);
+        try writer.writeInt(u32, to, .little);
+    }
+}
+
+pub const Node = struct {
+    data: Data,
+    name: []const u8,
+
+    pub const Data = union(enum) {
+        none,
+    };
+};
+
+pub const Edge = struct {
+    from: u32,
+    to: u32,
+};

--- a/src/modules/builtins.zig
+++ b/src/modules/builtins.zig
@@ -49,7 +49,7 @@ pub fn create(allocator: std.mem.Allocator) !Module {
 }
 
 /// https://docs.python.org/3.10/library/functions.html
-const builtin_fns = &.{
+pub const builtin_fns = &.{
     // // zig fmt: off
     .{ "abs", abs },
     .{ "bool", @"bool" },


### PR DESCRIPTION
By simply passing in `--graph` when running a script, and then running `plot.py` in the `graphs` directory on `graph.bin` which is placed in the cwd when you run the osmium, you can visualize the CF and byte code dependency graphs.

Examples:
![image](https://github.com/Rexicon226/osmium/assets/87927264/7fa368f3-1d4f-4cae-87a6-51f61003d14b)
![image](https://github.com/Rexicon226/osmium/assets/87927264/0b757d8b-1435-4672-9b08-72545ef44647)
